### PR TITLE
Improvements, fixes and compatibility fixes for gor v0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ To install a specific version of the Gor package from a custom source url:
 check https://github.com/buger/gor/releases
 ```puppet
 class { '::gor':
-  version       => '0.14.1',
-  source_url    => 'https://github.com/buger/gor/releases/download/v0.14.1/gor_v0.14.1_x64.tar.gz'
+  version       => '0.15.1',
+  source_url    => 'https://github.com/buger/gor/releases/download/v0.15.1/gor_v0.15.1_x64.tar.gz'
   digest_string => 'ced467f51da7491a227b871c9894d351',
   digest_type   => 'md5',
   …
@@ -65,7 +65,7 @@ class { '::gor':
 To install gor to a different bin location:
 ```puppet
 class { '::gor':
-  binary_path => '/usr/bin/gor', # default: '/usr/local/bin/gor'
+  binary_path => '/usr/bin', # default: '/usr/local/bin'
   …
 }
 ```
@@ -77,6 +77,15 @@ class { '::gor':
     'GODEBUG' => 'netdns=go',
     'FOO'     => 'bar',
   }
+  …
+}
+```
+
+To run gor under a normal user account and limit gor's memory usage:
+```puppet
+class { '::gor':
+  memory_limit => '100M',
+  runuser      => 'gor',
   …
 }
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ check https://github.com/buger/gor/releases
 ```puppet
 class { '::gor':
   version       => '0.14.1',
-  digest_string => 'ced467f51da7491a227b871c9894d351',
+  digest_string => '0c0335a323c416569f030f46a7541045',
   digest_type   => 'md5',
   …
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,8 +10,10 @@ class gor::config {
     $ensure = $::gor::ensure
   }
 
-  $envvars     = $::gor::envvars
-  $binary_path = $::gor::binary_path
+  $binary_path     = $::gor::binary_path
+  $envvars         = $::gor::envvars
+  $gor_memorylimit = $::gor::memory_limit
+  $gor_runuser     = $::gor::runuser
 
   $log_ensure = $ensure ? {
     present => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,38 +4,52 @@
 #
 # === Parameters
 #
+# [*args*]
+#   Hash of arguments to run Gor with. Values will be single quoted.
+#
+# [*binary_path*]
+#   Specify the location of the Gor binary.
+#
 # [*ensure*]
 #   Ensure parameter to pass to the package.
 #   Default: present
-#
-# [*version*]
-#   version of the package.
-#   Default: 0.14.1
-#
-# [*service_ensure*]
-#   Ensure parameter to pass to the service.
-#   Default: running
 #
 # [*envvars*]
 #   Environment variables to be passed into the upstart config. This could
 #   be used to turn on debugging options.
 #
-# [*binary_path*]
-#   Specify the location of the Gor binary.
+# [*memory_limit*]
+#   Limit using cgroups the amount of memory that gor is allowed to use at
+#   most. Currently only implemented for RHEL and derivatives. Default is
+#   unlimited.
 #
-# [*args*]
-#   Hash of arguments to run Gor with. Values will be single quoted.
+# [*runuser*]
+#   Defines as which user gor executable should be running. Currently only
+#   implemented for RHEL and derivatives. You need to make sure the user already
+#   exists. If this is set to something other than 'root' (the default) then gor
+#   will also be given capabilities through capset to do it's thing.
+#
+# [*service_ensure*]
+#   Ensure parameter to pass to the service.
+#   Default: running
+#
+# [*version*]
+#   version of the package.
+#   Default: 0.15.1
+#
 #
 class gor (
   $ensure         = present,
-  $version        = '0.14.1',
+  $version        = '0.15.1',
   $digest_string  = 'ced467f51da7491a227b871c9894d351',
   $digest_type    = 'md5',
   $source_url     = undef,
   $manage_service = true,
+  $memory_limit   = 'unlimited',
+  $runuser        = 'root',
   $service_ensure = running,
   $envvars        = {},
-  $binary_path    = '/usr/local/bin/gor',
+  $binary_path    = '/usr/local/bin',
   $args           = {}
 ) {
 
@@ -54,3 +68,4 @@ class gor (
   Class['gor::package'] ~> Class['gor::config']
   Class['gor::config'] ~> Class['gor::service']
 }
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@
 class gor (
   $ensure         = present,
   $version        = '0.15.1',
-  $digest_string  = 'ced467f51da7491a227b871c9894d351',
+  $digest_string  = '0c0335a323c416569f030f46a7541045',
   $digest_type    = 'md5',
   $source_url     = undef,
   $manage_service = true,

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -13,7 +13,7 @@ describe 'gor', :type => 'class' do
         :args => { '--foo' => 'bar' },
       }}
 
-      it { should contain_archive('gor-0.14.1').with_ensure('present') }
+      it { should contain_archive('gor-0.15.1').with_ensure('present') }
     end
 
     context '1.2.3' do

--- a/templates/gor.systemd.erb
+++ b/templates/gor.systemd.erb
@@ -4,14 +4,17 @@ After=network.target
 Wants=network.target
 
 [Service]
-<%  @envvars.each do |k, v| %>
+<%  @envvars.each do |k, v| -%>
 <%="Environment=#{k}='#{v}'" -%>
-<%  end %>
-ExecStart=<%= @binary_path %> \
+<%  end -%>
+User=<%= @gor_runuser %>
+MemoryAccounting=true
+MemoryLimit=<%= @gor_memorylimit %>
+ExecStart=<%= @binary_path %>/gor \
   <%=
 @args.sort.map { |k,v|
   [v].flatten.map { |i|
-    "#{k}='#{i}'"
+    "#{k} #{i}"
   }
 }.join(" \\\n  ")
 %> \
@@ -19,3 +22,4 @@ ExecStart=<%= @binary_path %> \
 
 [Install]
 WantedBy=multi-user.target
+

--- a/templates/gor.upstart.erb
+++ b/templates/gor.upstart.erb
@@ -10,7 +10,7 @@ respawn limit 5 20
 <%=   "env #{k}='#{v}'" -%>
 <%  end %>
 
-exec <%= @binary_path %> \
+exec <%= @binary_path %>/gor \
   <%=
 @args.sort.map { |k,v|
   [v].flatten.map { |i|


### PR DESCRIPTION
Sort documentation by abc, update version and add runuser for possible
security improvement

set capabilities for gor so it can run as normal user.

Add memory limitation possibility through cgroups for RHEL based hosts.

remove useless space after service section

Update documentation and fix binary_path not being used
